### PR TITLE
Add SwiftUI countdown app and widget

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,51 @@
+// swift-tools-version:5.6
+import PackageDescription
+
+let package = Package(
+    name: "Countdown",
+    platforms: [
+        .iOS(.v16)
+    ],
+    products: [
+        .iOSApplication(
+            name: "Countdown",
+            targets: ["Countdown"],
+            bundleIdentifier: "com.example.countdown",
+            teamIdentifier: "",
+            displayVersion: "1.0",
+            bundleVersion: "1",
+            appIcon: .placeholder(iconName: "AppIcon"),
+            accentColor: .presetColor(.blue),
+            supportedDeviceFamilies: [
+                .phone,
+                .pad
+            ],
+            supportedInterfaceOrientations: [
+                .portrait,
+                .landscapeLeft,
+                .landscapeRight,
+                .portraitUpsideDown
+            ],
+            additionalTargets: ["CountdownWidget"]
+        ),
+        .library(name: "CountdownKit", targets: ["CountdownKit"])
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .executableTarget(
+            name: "Countdown",
+            dependencies: ["CountdownKit"],
+            path: "Sources/Countdown"
+        ),
+        .executableTarget(
+            name: "CountdownWidget",
+            dependencies: ["CountdownKit"],
+            path: "Sources/CountdownWidget"
+        ),
+        .target(
+            name: "CountdownKit",
+            path: "Sources/CountdownKit"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # Countdown
+
+This repository contains a simple SwiftUI countdown application with an optional home screen widget. The project is organized as a Swift Package so that it can be opened directly in Xcode.
+
+## Features
+
+- Manage multiple countdown events.
+- Add a title and target date for each countdown.
+- Persistent storage shared with the home screen widget via an app group.
+- Widget displays the next countdown.
+
+## Getting Started
+
+1. Clone the repository and open `Package.swift` in Xcode.
+2. Create an App Group with the identifier `group.countdown` and enable it for both the app and the widget targets.
+3. Build and run on a device or simulator running iOS 16 or later.
+
+Use the `+` button in the app to create countdowns. Long‑press the home screen, tap the `+` button and add the *Countdown* widget to view your next countdown.

--- a/Sources/Countdown/ContentView.swift
+++ b/Sources/Countdown/ContentView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+import CountdownKit
+
+struct ContentView: View {
+    @EnvironmentObject var store: CountdownStore
+    @State private var showingAdd = false
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(store.items) { item in
+                    CountdownRow(item: item)
+                }
+                .onDelete(perform: store.delete)
+            }
+            .navigationTitle("Countdowns")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showingAdd = true }) {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingAdd) {
+                AddCountdownView()
+                    .environmentObject(store)
+            }
+        }
+    }
+}
+
+struct CountdownRow: View {
+    let item: CountdownItem
+    @State private var now: Date = Date()
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(item.title)
+                .font(.headline)
+            Text(timeRemainingString)
+                .font(.body)
+        }
+        .onReceive(timer) { input in
+            now = input
+        }
+    }
+
+    private var timeRemainingString: String {
+        let diff = Calendar.current.dateComponents([.day, .hour, .minute, .second], from: now, to: item.date)
+        let d = diff.day ?? 0
+        let h = diff.hour ?? 0
+        let m = diff.minute ?? 0
+        let s = diff.second ?? 0
+        return String(format: "%dd %02dh %02dm %02ds", d, h, m, s)
+    }
+}
+
+struct AddCountdownView: View {
+    @EnvironmentObject var store: CountdownStore
+    @Environment(\.dismiss) private var dismiss
+    @State private var title: String = ""
+    @State private var date: Date = Date().addingTimeInterval(3600)
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Title", text: $title)
+                DatePicker("Date", selection: $date)
+            }
+            .navigationTitle("Add Countdown")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Add") {
+                        store.add(title: title, date: date)
+                        dismiss()
+                    }
+                    .disabled(title.isEmpty)
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", action: { dismiss() })
+                }
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+            .environmentObject(CountdownStore())
+    }
+}

--- a/Sources/Countdown/CountdownApp.swift
+++ b/Sources/Countdown/CountdownApp.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import WidgetKit
+import CountdownKit
+
+@main
+struct CountdownApp: App {
+    @StateObject private var store = CountdownStore()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(store)
+        }
+        .onChange(of: store.items) { _ in
+            WidgetCenter.shared.reloadAllTimelines()
+        }
+    }
+}

--- a/Sources/CountdownKit/CountdownItem.swift
+++ b/Sources/CountdownKit/CountdownItem.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+struct CountdownItem: Identifiable, Codable {
+    let id: UUID
+    var title: String
+    var date: Date
+
+    init(id: UUID = UUID(), title: String, date: Date) {
+        self.id = id
+        self.title = title
+        self.date = date
+    }
+}
+
+class CountdownStore: ObservableObject {
+    @Published var items: [CountdownItem] = [] {
+        didSet { save() }
+    }
+
+    private let storageURL: URL = {
+        let container = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.countdown")
+        return container?.appendingPathComponent("countdowns.json") ?? FileManager.default.temporaryDirectory.appendingPathComponent("countdowns.json")
+    }()
+
+    init() {
+        load()
+    }
+
+    func add(title: String, date: Date) {
+        let item = CountdownItem(title: title, date: date)
+        items.append(item)
+    }
+
+    func delete(at offsets: IndexSet) {
+        items.remove(atOffsets: offsets)
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: storageURL) else { return }
+        if let decoded = try? JSONDecoder().decode([CountdownItem].self, from: data) {
+            items = decoded
+        }
+    }
+
+    private func save() {
+        guard let data = try? JSONEncoder().encode(items) else { return }
+        try? data.write(to: storageURL)
+    }
+}

--- a/Sources/CountdownWidget/CountdownWidget.swift
+++ b/Sources/CountdownWidget/CountdownWidget.swift
@@ -1,0 +1,72 @@
+import WidgetKit
+import SwiftUI
+import CountdownKit
+
+struct CountdownEntry: TimelineEntry {
+    let date: Date
+    let item: CountdownItem?
+}
+
+struct CountdownProvider: TimelineProvider {
+    func placeholder(in context: Context) -> CountdownEntry {
+        CountdownEntry(date: Date(), item: CountdownItem(title: "Sample", date: Date().addingTimeInterval(3600)))
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (CountdownEntry) -> ()) {
+        let entry = CountdownEntry(date: Date(), item: loadFirst())
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<CountdownEntry>) -> ()) {
+        let entry = CountdownEntry(date: Date(), item: loadFirst())
+        let timeline = Timeline(entries: [entry], policy: .never)
+        completion(timeline)
+    }
+
+    private func loadFirst() -> CountdownItem? {
+        let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.countdown")?.appendingPathComponent("countdowns.json")
+        guard let url, let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode([CountdownItem].self, from: data).first
+    }
+}
+
+struct CountdownWidgetEntryView : View {
+    var entry: CountdownProvider.Entry
+
+    var body: some View {
+        if let item = entry.item {
+            VStack(alignment: .leading) {
+                Text(item.title)
+                    .font(.headline)
+                Text(timeRemainingString(for: item))
+                    .font(.body)
+            }
+            .padding()
+        } else {
+            Text("No Countdowns")
+        }
+    }
+
+    private func timeRemainingString(for item: CountdownItem) -> String {
+        let diff = Calendar.current.dateComponents([.day, .hour, .minute, .second], from: Date(), to: item.date)
+        let d = diff.day ?? 0
+        let h = diff.hour ?? 0
+        let m = diff.minute ?? 0
+        let s = diff.second ?? 0
+        return String(format: "%dd %02dh %02dm %02ds", d, h, m, s)
+    }
+}
+
+@main
+struct CountdownWidget: Widget {
+    let kind: String = "CountdownWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: CountdownProvider()) { entry in
+            CountdownWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Countdown")
+        .description("View your next countdown")
+        .supportedFamilies([.systemSmall])
+    }
+}


### PR DESCRIPTION
## Summary
- provide a Swift Package-based iOS app with SwiftUI
- include a countdown list, add form and persistence
- store countdowns in an app group so the widget can read them
- implement a basic widget showing the next countdown
- update README with build instructions

## Testing
- `git status`

------
https://chatgpt.com/codex/tasks/task_e_6877ea75a138832a96223c95f799c94d